### PR TITLE
Change base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,15 @@ To build the image, navigate to the `document-converter` directory.
 
 ```bash
 cd document-converter
-docker build -t ftsrg/document-converter .
+docker build -t ftsrg/document-converter:2020 .
+docker tag ftsrg/document-converter:2020 ftsrg/document-converter:latest
 ```
 
 To deploy the image on Docker Hub, run:
 
 ```bash
-docker push ftsrg/document-converter
+docker push ftsrg/document-converter:2020
+docker push ftsrg/document-converter:latest
 ```
 
 ## Local usage

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,6 @@ outputs:
     description: 'The time it took to build the PDFs'
 runs:
   using: 'docker'
-  image: 'docker://ftsrg/document-converter'
+  image: 'docker://ftsrg/document-converter:2020'
   args:
     - ${{ inputs.makefile-arguments }}

--- a/document-converter/Dockerfile
+++ b/document-converter/Dockerfile
@@ -1,6 +1,6 @@
-FROM makisyu/texlive-2020
+FROM texlive/texlive:latest
 
-RUN dnf install -y the_silver_searcher pandoc ncurses-compat-libs
+RUN apt-get update && apt-get install -y silversearcher-ag pandoc
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/document-converter/Dockerfile
+++ b/document-converter/Dockerfile
@@ -1,6 +1,9 @@
 FROM registry.gitlab.com/islandoftex/images/texlive:TL2020-2021-03-21-04-14@sha256:f2b367a2548683eaf15a3dcd5eac50e4104e42140b9337d66a9f9950579d4c77
 
-RUN apt-get update && apt-get install -y silversearcher-ag pandoc
+RUN apt-get update && apt-get install -y \
+    silversearcher-ag \
+    pandoc \
+ && rm -rf /var/lib/apt/lists/*
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/document-converter/Dockerfile
+++ b/document-converter/Dockerfile
@@ -1,4 +1,4 @@
-FROM texlive/texlive:latest
+FROM registry.gitlab.com/islandoftex/images/texlive:TL2020-2021-03-21-04-14@sha256:f2b367a2548683eaf15a3dcd5eac50e4104e42140b9337d66a9f9950579d4c77
 
 RUN apt-get update && apt-get install -y silversearcher-ag pandoc
 


### PR DESCRIPTION
It seems there's an official, Debian-based TeX Live Docker image. It is much smaller than the Fedora-based image we're currently using:
```
texlive/texlive                  latest              4c14932265e9        3 days ago          4.74GB
makisyu/texlive-2020             latest              ee40185e97ca        4 months ago        7.92GB
```

So we should consider switching to it: https://hub.docker.com/r/texlive/texlive/tags

It currently does not have a tag for `TL2020` so I just used `:latest.`
If we would like to pin it to a specific version, we need to use a commit hash.
