### PR TITLE
Update to TL2022-v20230319

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,24 @@ Used in our private repositories to build syllabi for the Systems Modelling cour
 
 ## Base image
 
-The Docker image is built based on the configuration in `document-converter` and it is deployed on [`Docker Hub`](https://hub.docker.com/r/ftsrg/document-converter).
+The Docker image is built based on the configuration in `document-converter` and it is deployed on [`GitHub Container Registry`](https://ghcr.io/ftsrg/document-converter).
 
 To build the image, navigate to the `document-converter` directory.
 
 ```bash
 cd document-converter
-docker build -t ftsrg/document-converter:2020-v20220329 .
-docker tag ftsrg/document-converter:2020-v20220329 ftsrg/document-converter:2020
-docker tag ftsrg/document-converter:2020 ftsrg/document-converter:latest
+docker build -t ghcr.io/ftsrg/document-converter:2022-v20230319 .
+docker tag ghcr.io/ftsrg/document-converter:2022-v20230319 ghcr.io/ftsrg/document-converter:2022
+docker tag ghcr.io/ftsrg/document-converter:2022 ghcr.io/ftsrg/document-converter:latest
 ```
 
-To deploy the image on Docker Hub, run:
+To deploy the image on GitHub Container Registry, run:
 
 ```bash
-docker push ftsrg/document-converter:2020-v20220329
-docker push ftsrg/document-converter:2020
-docker push ftsrg/document-converter:latest
+echo $PAT | docker login ghcr.io -u <user> --password-stdin # PAT must have {read,write,delete}:packages scopes enabled
+docker push ghcr.io/ftsrg/document-converter:2022-v20230319
+docker push ghcr.io/ftsrg/document-converter:2022
+docker push ghcr.io/ftsrg/document-converter:latest
 ```
 
 ## Local usage
@@ -32,7 +33,7 @@ docker push ftsrg/document-converter:latest
 To use this Docker image, create a `Makefile` that performs the required build steps. Then, test the image as follows;
 
 ```bash
-docker run --rm -v `pwd`:"/github/workspace" ftsrg/document-converter:2020 [arguments]
+docker run --rm -v `pwd`:"/github/workspace" ghcr.io/ftsrg/document-converter:2022 [arguments]
 ```
 
 The `[arguments]` are optional and are passed to the Makefile.
@@ -49,7 +50,7 @@ jobs:
     name: ...
     steps:
     - name: Build PDFs with the LaTeX engine in Docker
-      uses: ftsrg/document-converter-actions@2020
+      uses: ghcr.io/ftsrg/document-converter-actions@2022
       with:
         makefile-arguments: ci
 ```

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,6 @@ outputs:
     description: 'The time it took to build the PDFs'
 runs:
   using: 'docker'
-  image: 'docker://ftsrg/document-converter:2020-v20220329'
+  image: 'docker://ftsrg/document-converter:2022-v20230319'
   args:
     - ${{ inputs.makefile-arguments }}

--- a/document-converter/Dockerfile
+++ b/document-converter/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/islandoftex/images/texlive:TL2020-2021-04-04-04-11@sha256:824430519e6708dcedea8c94b7c3d11f20a4acfbfd30ca7ec1c0317c33c880d4
+FROM registry.gitlab.com/islandoftex/images/texlive:TL2022-2023-03-19-full@sha256:9d1f16e3c919e67267bb5a9796bee6f51c8265927f0bf99952241981a60c1d8d
 
 RUN apt-get update && apt-get install -y \
     silversearcher-ag \


### PR DESCRIPTION
This PR updates TL to one of the latest releases, necessary for (among others) https://github.com/ftsrg/paper-jsa-networkcat.

I don't have push access to Docker Hub, so I was not able to push the docker image there, which is necessary before this PR can be merged. The tag should be `2022-v20230319`, (action.yml has already been updated to use this tag).
